### PR TITLE
Add libbpf_set_max_verifier_log_output()

### DIFF
--- a/src/libbpf.h
+++ b/src/libbpf.h
@@ -58,6 +58,8 @@ typedef int (*libbpf_print_fn_t)(enum libbpf_print_level level,
 
 LIBBPF_API libbpf_print_fn_t libbpf_set_print(libbpf_print_fn_t fn);
 
+LIBBPF_API size_t libbpf_set_max_verifier_log_output(size_t size);
+
 /* Hide internal to user */
 struct bpf_object;
 

--- a/src/libbpf.map
+++ b/src/libbpf.map
@@ -382,4 +382,5 @@ LIBBPF_0.5.0 {
 		btf__load_vmlinux_btf;
 		btf_dump__dump_type_data;
 		libbpf_set_strict_mode;
+		libbpf_set_max_verifier_log_output;
 } LIBBPF_0.4.0;


### PR DESCRIPTION
The global function is used to limit the BPF verifier log output. It
ensures that max last characters will only be printed.

The change hasn't been upstreamed yet. Once it has been, the commit will
be replaced (for now this is solely to avoid generating large sysdumps in the CI
when testing the unreleased v1.11 cilium).

Related https://github.com/cilium/cilium/issues/17178.